### PR TITLE
Bump version and update CI workflow name

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,13 +1,11 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
-name: eprllib
+name: Deploy eprllib on PyPI
 
 on:
   release:
     types: [published]
-
-# Se ha eliminado FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 para evitar la advertencia de forzado.
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "eprllib"
 # La versión se obtiene dinámicamente del archivo version.py
 dynamic = ["version", "dependencies"]
-metadata = "2.2"
+
 authors = [
   { name="Germán Rodolfo Henderson"},
 ]

--- a/src/eprllib/version.py
+++ b/src/eprllib/version.py
@@ -3,7 +3,7 @@ Version Management
 =====================
 """
 
-__version__ = "1.7.12"
+__version__ = "1.7.13"
 
 EP_VERSION = "24-2-0"
 


### PR DESCRIPTION
Bump package version to 1.7.13 in src/eprllib/version.py for the new release. Rename GitHub Actions workflow to "Deploy eprllib on PyPI" and remove an obsolete comment in .github/workflows/python-publish.yml. Remove the unused metadata = "2.2" line from pyproject.toml (version and dependencies remain dynamic).