### PR TITLE
fix: cast agent observations to float32 in BaseFilter

### DIFF
--- a/src/eprllib/Agents/Filters/BaseFilter.py
+++ b/src/eprllib/Agents/Filters/BaseFilter.py
@@ -17,6 +17,7 @@ You have to overwrite the following methods:
     
 """
 from typing import Any, Dict
+import numpy as np
 from numpy import floating
 from numpy.typing import NDArray
 
@@ -87,7 +88,7 @@ class BaseFilter:
         # Generate a copy of the agent_states to avoid conflicts with global variables.
         agent_states_copy = agent_states.copy()
         
-        return self._get_filtered_obs(agent_states_copy)
+        return self._get_filtered_obs(agent_states_copy).astype(np.float32)
     
     
     # ===========================


### PR DESCRIPTION
- Added explicit .astype(np.float32) to get_filtered_obs return value.
- Resolves Gymnasium precision warnings (float64 to float32 casting).
- Fixes observation space validation errors caused by precision discrepancies.